### PR TITLE
Chap7 kubernetes

### DIFF
--- a/.github/workflows/commit-stage.yaml
+++ b/.github/workflows/commit-stage.yaml
@@ -35,6 +35,11 @@ jobs:
         run: |
           chmod +x gradlew
           ./gradlew build
+      - name: Validate Kubernetes manifest
+        uses: "stackrox/kube-linter-action@v1.0.7"
+        with:
+          directory: k8s
+          fail-on-invalid-resource: true
   package:
     name: "Package and Publish"
     if: "${{ github.ref == 'refs/heads/main'}}"

--- a/TiltFile
+++ b/TiltFile
@@ -1,0 +1,15 @@
+# Build
+custom_build(
+    # Name of the container image
+    ref = 'config-service',
+    # Command to build the image - using env parameter for cross-platform compatibility
+    command='gradlew bootBuildImage --imageName %EXPECTED_REF%',
+    # files to watch for changes
+    deps=['build.gradle.kts', 'src']
+)
+
+# Deploy
+k8s_yaml(['k8s/deployment.yaml', 'k8s/service.yaml'])
+
+# Manage
+k8s_resource('config-service')

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ tasks.named<BootBuildImage>("bootBuildImage") {
         "LANGUAGE" to "ja_JP:ja",
         "LC_ALL" to "ja_JP.UTF-8"
     )
-    imageName = project.name
+    imageName = project.name + ":" + project.version
     docker {
         publishRegistry {
             username = project.findProperty("registryUsername")?.toString()

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: config-service
+  labels:
+    app: config-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: config-service
+  template:
+    metadata:
+      labels:
+        app: config-service
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      volumes:
+    spec:
+      containers:
+        - name: config-service
+          image: config-service:0.0.1-SNAPSHOT
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command: [ "sh", "-c", "sleep 5" ]
+          ports:
+            - containerPort: 9001
+          env:
+            - name: BPL_JVM_THREAD_COUNT
+              value: "50"
+            - name: SPRING_DATASOURCE_URL
+              value: jdbc:postgresql://polar-postgres/polardb_catalog
+            - name: SPRING_PROFILES_ACTIVE
+              value: testdata
+            - name: HOME
+              value: /home/cnb
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "200m"
+            limits:
+              memory: "1024Mi"
+              cpu: "400m"
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: cnb-home
+              mountPath: /home/cnb
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            runAsUser: 1000
+            runAsGroup: 1000
+      volumes:
+        - name: tmp
+          emptyDir: { }
+        - name: cnb-home
+          emptyDir: { }
+
+

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: config-service
+  labels:
+    app: config-service
+spec:
+  type: ClusterIP
+  selector:
+    app: config-service
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8888

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,9 +1,6 @@
 spring:
   application:
     name: config-service
-
-  config:
-    additional-location: "classpath:/local/application-local.yaml"
   cloud:
     config:
       server:
@@ -13,8 +10,11 @@ spring:
           timeout: 5
           clone-on-start: true
           force-pull: true
+  lifecycle:
+    timeout-per-shutdown-phase: 15s
 server:
   port: 8888
+  shutdown: graceful
   tomcat:
     connection-timeout: 2s
     keep-alive-timeout: 15s


### PR DESCRIPTION
This pull request introduces Kubernetes deployment support and related tooling for the `config-service`, along with some minor configuration improvements. The main changes include adding Kubernetes manifests, integrating validation and local development tools, and updating application configuration for graceful shutdown.

**Kubernetes deployment and tooling:**

* Added `k8s/deployment.yaml` and `k8s/service.yaml` to define a `Deployment` and `Service` for `config-service`, including resource limits, environment variables, and security context for best practices. [[1]](diffhunk://#diff-4bbade0e44f036b32fc63c2e5838f57268ec49ff70dfce1afb9e12849515dd38R1-R65) [[2]](diffhunk://#diff-427c18a0ed4a36634147b26d71347f2755fb5db12571eb0ceb80949186700fc5R1-R14)
* Integrated Kubernetes manifest validation into the CI workflow using `kube-linter-action` to catch misconfigurations early. (.github/workflows/commit-stage.yaml)
* Added a `TiltFile` for local development, supporting custom image builds and deployment to Kubernetes with live updates.

**Application configuration improvements:**

* Enabled graceful shutdown and lifecycle timeout in `application.yaml` for safer deployments and rollouts.
* Removed unused or redundant configuration lines from `application.yaml` for clarity.