### PR TITLE
refactor deployment.yaml to move securityContext under spec and remov…

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -13,12 +13,11 @@ spec:
     metadata:
       labels:
         app: config-service
-    securityContext:
-      runAsNonRoot: true
-      runAsUser: 1000
-      runAsGroup: 1000
-      volumes:
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
       containers:
         - name: config-service
           image: config-service:0.0.1-SNAPSHOT
@@ -32,10 +31,6 @@ spec:
           env:
             - name: BPL_JVM_THREAD_COUNT
               value: "50"
-            - name: SPRING_DATASOURCE_URL
-              value: jdbc:postgresql://polar-postgres/polardb_catalog
-            - name: SPRING_PROFILES_ACTIVE
-              value: testdata
             - name: HOME
               value: /home/cnb
           resources:


### PR DESCRIPTION
This pull request makes minor updates to the Kubernetes deployment configuration for the `config-service`. The changes primarily involve cleaning up the deployment spec and environment variable definitions.

* Deployment spec cleanup:
  * Removed redundant `volumes` and duplicate `spec:` entries in the `k8s/deployment.yaml` file to simplify the configuration.

* Environment variable updates:
  * Removed unused environment variables: `SPRING_DATASOURCE_URL` and `SPRING_PROFILES_ACTIVE` from the container definition in `k8s/deployment.yaml`.…e unused environment variables