### PR TITLE
Observability

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ extra["springCloudVersion"] = "2025.0.0"
 
 dependencies {
 	implementation("org.springframework.cloud:spring-cloud-config-server")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ extra["springCloudVersion"] = "2025.0.0"
 dependencies {
 	implementation("org.springframework.cloud:spring-cloud-config-server")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    runtimeOnly("io.micrometer:micrometer-registry-prometheus")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,8 @@ dependencies {
 	implementation("org.springframework.cloud:spring-cloud-config-server")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
+    runtimeOnly("io.micrometer:micrometer-tracing-bridge-otel")
+    runtimeOnly("io.opentelemetry:opentelemetry-exporter-otlp")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -4,10 +4,6 @@ metadata:
   name: config-service
   labels:
     app: config-service
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9001"
-    prometheus.io/path: "/actuator/prometheus"
 spec:
   replicas: 1
   selector:
@@ -17,6 +13,10 @@ spec:
     metadata:
       labels:
         app: config-service
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "9001"
+      prometheus.io/path: "/actuator/prometheus"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -51,6 +51,18 @@ spec:
             readOnlyRootFilesystem: true
             runAsUser: 1000
             runAsGroup: 1000
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 9000
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 9000
+            initialDelaySeconds: 10
+            periodSeconds: 5
       volumes:
         - name: tmp
           emptyDir: { }

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -31,7 +31,7 @@ spec:
               exec:
                 command: [ "sh", "-c", "sleep 5" ]
           ports:
-            - containerPort: 9001
+            - containerPort: 8888
           env:
             - name: BPL_JVM_THREAD_COUNT
               value: "50"
@@ -58,13 +58,13 @@ spec:
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness
-              port: 9000
+              port: 8888
             initialDelaySeconds: 10
             periodSeconds: 5
           readinessProbe:
             httpGet:
               path: /actuator/health/readiness
-              port: 9000
+              port: 8888
             initialDelaySeconds: 10
             periodSeconds: 5
       volumes:

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: config-service
   labels:
     app: config-service
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9001"
+    prometheus.io/path: "/actuator/prometheus"
 spec:
   replicas: 1
   selector:

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: config-service
     annotations:
       prometheus.io/scrape: "true"
-      prometheus.io/port: "9001"
+      prometheus.io/port: "8888"
       prometheus.io/path: "/actuator/prometheus"
     spec:
       securityContext:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,6 +12,17 @@ spring:
           force-pull: true
   lifecycle:
     timeout-per-shutdown-phase: 15s
+  management:
+    endpoints:
+      web:
+        exposure:
+          include: health
+    endpoint:
+      health:
+        show-details: always
+        show-components: always
+        probes:
+          enabled: true
 server:
   port: 8888
   shutdown: graceful

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,7 +12,7 @@ spring:
           force-pull: true
   lifecycle:
     timeout-per-shutdown-phase: 15s
-  management:
+management:
     endpoints:
       web:
         exposure:
@@ -26,6 +26,14 @@ spring:
     metrics:
       tags:
         application: ${spring.application.name}
+    tracing:
+      sampling:
+        probability: 1.0
+    otlp:
+      tracing:
+        endpoint: http://localhost:4318/v1/traces
+        compression: none
+        timeout: 10s
 server:
   port: 8888
   shutdown: graceful

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,7 +16,7 @@ spring:
     endpoints:
       web:
         exposure:
-          include: health
+          include: health,prometheus
     endpoint:
       health:
         show-details: always

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -23,6 +23,9 @@ spring:
         show-components: always
         probes:
           enabled: true
+    metrics:
+      tags:
+        application: ${spring.application.name}
 server:
   port: 8888
   shutdown: graceful


### PR DESCRIPTION
This pull request introduces improvements for observability and reliability in the configuration service by enabling Prometheus metrics scraping, configuring health probes in the Kubernetes deployment, and enhancing Spring Boot actuator endpoints and tracing. These changes help with monitoring, alerting, and troubleshooting the service.

**Observability and Monitoring Enhancements:**

* Added Prometheus scraping annotations (`prometheus.io/scrape`, `prometheus.io/port`, `prometheus.io/path`) to the Kubernetes deployment for metrics collection.
* Updated `application.yaml` to expose `health` and `prometheus` endpoints, always show health details and components, enable probes, and add application tags to metrics.

**Reliability Improvements:**

* Configured Kubernetes `livenessProbe` and `readinessProbe` to use actuator health endpoints, improving automated detection of unhealthy pods.

**Tracing and Telemetry:**

* Enabled distributed tracing in Spring Boot with full sampling, OTLP endpoint configuration, and custom timeouts to support end-to-end request tracing.